### PR TITLE
fix: from_timer was renamed to timer_container_of with Kernel 6.16rc1

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -729,7 +729,14 @@ struct rtw_timer_list {
 	void *arg;
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
+static inline void timer_hdl(struct timer_list *in_timer)
+{
+	_timer *ptimer = timer_container_of(ptimer, in_timer, timer);
+
+	ptimer->function(ptimer->arg);
+}
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
 static inline void timer_hdl(struct timer_list *in_timer)
 {
 	_timer *ptimer = from_timer(ptimer, in_timer, timer);


### PR DESCRIPTION
It seems that in Kernel 6.16 _from_timer_ was renamed to _timer_container_of_.

I'm on Kernel 6.16 and the build failed. With this change it built just fine.